### PR TITLE
Verify client id has the right capitalization

### DIFF
--- a/Office365RESTAPIExplorer/App.xaml.cs
+++ b/Office365RESTAPIExplorer/App.xaml.cs
@@ -36,7 +36,14 @@ namespace Office365RESTExplorerforSites
         // whenever you register the app using another account, this variable will be in sync with whatever is in App.xaml.
         internal string ClientId
         {
-            get { return Resources["ida:ClientID"].ToString(); }
+            get {
+                // Older versions of thye 'Connected Service' experience
+                // inject ClientID to App.xaml, newer inject ClientId.
+                // Just check for both.
+                return Resources.ContainsKey("ida:ClientId") ?
+                    Resources["ida:ClientId"].ToString() :
+                    Resources["ida:ClientID"].ToString();
+            }
         }
         internal Uri ReturnUri
         {


### PR DESCRIPTION
Updated ClientId retrieval to work with older and newer versions of the _Connected Services_ experience. This closes #7.
